### PR TITLE
Development

### DIFF
--- a/.github/workflows/binary_builder.yaml
+++ b/.github/workflows/binary_builder.yaml
@@ -2,10 +2,12 @@ name: Build and Package Agents-Fun
 
 on:
   push:
-    branches:
-      - development
+    tags:
+      - 'v*'
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/agents-fun/src/initCharacter.ts
+++ b/agents-fun/src/initCharacter.ts
@@ -19,7 +19,7 @@ export async function initCharacter(): Promise<{ character: Character; token: st
     TWITTER_USERNAME: config.twitterUsername,
     TWITTER_PASSWORD: config.twitterPassword,
     TWITTER_EMAIL: config.twitterEmail,
-    AGENT_EOA_PK: "", // agent wallet key loaded elsewhere if needed
+    AGENT_EOA_PK: config.pvtKey, // agent wallet key loaded elsewhere if needed
     BASE_LEDGER_RPC: config.baseLedgerRpc,
     MEME_FACTORY_CONTRACT: config.memeFactoryContract,
     SAFE_ADDRESS_DICT: config.safeAddressDict,

--- a/agents-fun/src/initConfig.ts
+++ b/agents-fun/src/initConfig.ts
@@ -1,6 +1,6 @@
 // src/initConfig.ts
 import dotenv from "dotenv";
-import { SUBGRAPH_URLS, CONTRACTS } from "./config/index";
+import { SUBGRAPH_URLS, CONTRACTS, prepareAgentPaths } from "./config/index";
 
 dotenv.config();  // load .env file if present
 
@@ -22,6 +22,7 @@ export interface Config {
   twitterPassword: string;
   twitterEmail: string;
   serverPort: number;  // add port for DirectClient server
+  pvtKey: string;
 }
 
 /**
@@ -47,6 +48,8 @@ export function loadConfig(): Config {
   process.env.USE_OPENAI_EMBEDDING_TYPE = process.env.USE_OPENAI_EMBEDDING_TYPE ?? "true";
   process.env.CHAIN_ID = process.env.CHAIN_ID ?? "8453";
 
+  process.env.AGENT_EOA_PK = prepareAgentPaths();
+
   return {
     storePath,
     openAiApiKey: requireEnv("CONNECTION_CONFIGS_CONFIG_OPENAI_API_KEY"),
@@ -62,5 +65,6 @@ export function loadConfig(): Config {
     twitterPassword: requireEnv("CONNECTION_CONFIGS_CONFIG_TWIKIT_PASSWORD"),
     twitterEmail: requireEnv("CONNECTION_CONFIGS_CONFIG_TWIKIT_EMAIL"),
     serverPort: parseInt(process.env.SERVER_PORT ?? process.env.CONNECTION_CONFIGS_CONFIG_SERVER_PORT ?? "8716", 10),
+    pvtKey: requireEnv("AGENT_EOA_PK"),
   };
 }

--- a/agents-fun/src/initConfig.ts
+++ b/agents-fun/src/initConfig.ts
@@ -47,9 +47,6 @@ export function loadConfig(): Config {
   process.env.USE_OPENAI_EMBEDDING_TYPE = process.env.USE_OPENAI_EMBEDDING_TYPE ?? "true";
   process.env.CHAIN_ID = process.env.CHAIN_ID ?? "8453";
 
-  // Parse JSON strings for RPC and Safe addresses
-  const baseLedgerRpcJson = JSON.parse(requireEnv("CONNECTION_CONFIGS_CONFIG_BASE_LEDGER_RPC"));
-
   return {
     storePath,
     openAiApiKey: requireEnv("CONNECTION_CONFIGS_CONFIG_OPENAI_API_KEY"),
@@ -58,7 +55,7 @@ export function loadConfig(): Config {
     subgraphUrl: SUBGRAPH_URLS.USER_SUBGRAPH_URL,
     memeSubgraphUrl: SUBGRAPH_URLS.MEME_SUBGRAPH_URL,
     chainId: requireEnv("CHAIN_ID"),
-    baseLedgerRpc: baseLedgerRpcJson.base,
+    baseLedgerRpc: requireEnv("CONNECTION_CONFIGS_CONFIG_BASE_LEDGER_RPC"),
     memeFactoryContract: CONTRACTS.MEME_FACTORY_CONTRACT,
     safeAddressDict: requireEnv("CONNECTION_CONFIGS_CONFIG_SAFE_CONTRACT_ADDRESSES"),
     twitterUsername: requireEnv("CONNECTION_CONFIGS_CONFIG_TWIKIT_USERNAME"),


### PR DESCRIPTION
This pull request introduces changes to the build workflow and configuration handling in the `agents-fun` project. The most notable updates include modifying the GitHub Actions workflow to trigger on tag pushes and releases, adding a private key (`pvtKey`) to the configuration, and refactoring how environment variables are managed for agent initialization.

### Workflow Updates:
* [`.github/workflows/binary_builder.yaml`](diffhunk://#diff-443197641c5682d98c2a5d28fb13188b712e23e0d5abba94fec342d21176fe84L5-R10): Updated the workflow to trigger on tag pushes (`v*`) and release events (`published`) instead of the `development` branch. This aligns the workflow with a release-driven process.

### Configuration Enhancements:
* `agents-fun/src/initConfig.ts`:
  - Added a new `pvtKey` field to the `Config` interface and ensured it is loaded from the environment variables. [[1]](diffhunk://#diff-b70fce3e527c0a7cebbdac1e6837248ce74929477bc3dadc3092879a2e73ca0eR25) [[2]](diffhunk://#diff-b70fce3e527c0a7cebbdac1e6837248ce74929477bc3dadc3092879a2e73ca0eL61-R68)
  - Introduced the `prepareAgentPaths` function to set up the `AGENT_EOA_PK` environment variable dynamically.

### Code Adjustments:
* [`agents-fun/src/initCharacter.ts`](diffhunk://#diff-5cf3e202f717a9dc68dee0af2ee183b9d0dcfff3b7e5cd80e871b1e6c52d50e6L22-R22): Replaced the hardcoded empty string for `AGENT_EOA_PK` with the dynamically loaded `config.pvtKey`. This ensures the private key is properly passed during agent initialization.