### PR TITLE
Development

### DIFF
--- a/.github/workflows/binary_builder.yaml
+++ b/.github/workflows/binary_builder.yaml
@@ -128,8 +128,16 @@ jobs:
             cp ./binary-builder/target/release/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION} ./release-assets/
           fi
 
-      - name: Upload artifact
+      - name: Upload artifact (Linux and macOS)
+        if: matrix.os_name == 'linux' || matrix.os_name == 'darwin'
         uses: actions/upload-artifact@v4
         with:
           name: agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}
-          path: ./release-assets/*
+          path: ./release-assets/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_*
+
+      - name: Upload artifact (Windows)
+        if: matrix.os_name == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}
+          path: ./release-assets/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_*.exe

--- a/.github/workflows/binary_builder.yaml
+++ b/.github/workflows/binary_builder.yaml
@@ -117,16 +117,19 @@ jobs:
           $VERSION = (Get-Content agents-fun/package.json | ConvertFrom-Json).version
           Rename-Item -Path ./binary-builder/target/release/agentsFunEliza.exe -NewName agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION}.exe
 
-      - name: Upload artifact (Linux and macOS)
-        if: matrix.os_name == 'linux' || matrix.os_name == 'darwin'
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}
-          path: ./binary-builder/target/release/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION}
+      - name: Copy binaries to release-assets folder
+        shell: bash
+        run: |
+          mkdir -p ./release-assets
+          VERSION=$(jq -r '.version' agents-fun/package.json)
+          if [[ "${{ matrix.os_name }}" == "windows" ]]; then
+            cp ./binary-builder/target/release/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION}.exe ./release-assets/
+          else
+            cp ./binary-builder/target/release/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION} ./release-assets/
+          fi
 
-      - name: Upload artifact (Windows)
-        if: matrix.os_name == 'windows'
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}
-          path: ./binary-builder/target/release/agentsFunEliza_${{ matrix.os_name }}_${{ matrix.arch }}_${VERSION}.exe
+          path: ./release-assets/*

--- a/.github/workflows/release_creator.yaml
+++ b/.github/workflows/release_creator.yaml
@@ -29,11 +29,15 @@ jobs:
         with:
           path: ./release_assets
 
+      - name: Display downloaded artifacts
+        run: ls -R ./release_assets
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.package_version.outputs.version }}
           name: Release v${{ steps.package_version.outputs.version }}
-          files: ./release_assets/**/*
+          files: |
+            ./release_assets/agentsFunEliza_*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve artifact handling and release processes. Key changes include introducing a dedicated `release-assets` folder for organizing binaries and enhancing the release creation process by displaying downloaded artifacts.

### Workflow improvements:

* [`.github/workflows/binary_builder.yaml`](diffhunk://#diff-443197641c5682d98c2a5d28fb13188b712e23e0d5abba94fec342d21176fe84R120-R143): Added a step to copy binaries into a `release-assets` folder for better organization. Updated artifact upload paths to use the `release-assets` folder instead of directly referencing the build output directory.
* [`.github/workflows/release_creator.yaml`](diffhunk://#diff-a930ff6daeb7096ac678014f21d6322f614b6f66b9fd420916045d144efddcc2R32-R41): Added a step to display the contents of the `release_assets` directory to verify downloaded artifacts. Simplified the `files` input for the GitHub release action to include only the relevant binaries.